### PR TITLE
[Deps] Override brace-expansion@1, @2 and @5 to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
     "overrides": {
       "@cloudflare/workers-types": "4.20260317.1",
       "@unhead/vue": "2.1.13",
-      "brace-expansion@1": "1.1.13",
-      "brace-expansion@2": "^2.1.2",
-      "brace-expansion@5": "^5.0.6",
+      "brace-expansion@1": "^1.1.18",
+      "brace-expansion@2": "^2.1.4",
+      "brace-expansion@5": "^5.0.9",
       "devalue": "^5.8.1",
       "esbuild@^0.27.0": "0.28.1",
       "flatted": "3.4.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
       "@cloudflare/workers-types": "4.20260317.1",
       "@unhead/vue": "2.1.13",
       "brace-expansion@1": "1.1.13",
-      "brace-expansion@2": "2.0.3",
+      "brace-expansion@2": "^2.1.2",
       "brace-expansion@5": "^5.0.6",
       "devalue": "^5.8.1",
       "esbuild@^0.27.0": "0.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,9 @@ settings:
 overrides:
   '@cloudflare/workers-types': 4.20260317.1
   '@unhead/vue': 2.1.13
-  brace-expansion@1: 1.1.13
-  brace-expansion@2: ^2.1.2
-  brace-expansion@5: ^5.0.6
+  brace-expansion@1: ^1.1.18
+  brace-expansion@2: ^2.1.4
+  brace-expansion@5: ^5.0.9
   devalue: ^5.8.1
   esbuild@^0.27.0: 0.28.1
   flatted: 3.4.2
@@ -3348,15 +3348,15 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -10819,7 +10819,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -10828,7 +10828,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -13118,19 +13118,19 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@cloudflare/workers-types': 4.20260317.1
   '@unhead/vue': 2.1.13
   brace-expansion@1: 1.1.13
-  brace-expansion@2: 2.0.3
+  brace-expansion@2: ^2.1.2
   brace-expansion@5: ^5.0.6
   devalue: ^5.8.1
   esbuild@^0.27.0: 0.28.1
@@ -3351,8 +3351,8 @@ packages:
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -10824,7 +10824,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -13134,11 +13134,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Closes Dependabot alerts #141, #146, #148, #150, #151, #157, #158, #159 and #160 — all nine open brace-expansion alerts.

> Scope note: this PR originally moved only `brace-expansion@2`, which closed 3 of the 9 alerts. It has been extended to cover the other two majors resolved in the tree.

## Problem

Three separate majors of `brace-expansion` are resolved in the lockfile, each reached through a different `minimatch`. Only `@2` was being patched:

| Override | Was | Consumers | Status |
|---|---|---|---|
| `brace-expansion@1` | `1.1.13` (exact pin) | `minimatch@3.1.5` | vulnerable |
| `brace-expansion@2` | `^2.1.2` → 2.1.4 | `minimatch@5.1.9`, `minimatch@9.0.9` | patched |
| `brace-expansion@5` | `^5.0.6` → 5.0.6 | `minimatch@10.2.4/.5/.6` | vulnerable |

The nine advisories are four distinct DoS bugs, each re-reported per affected major:

| Alert | Sev | Advisory | Needs |
|---|---|---|---|
| [#146](https://github.com/Symprex/link-shortener/security/dependabot/146) | high | Exponential-time expansion of consecutive non-expanding `{}` groups | 1.1.16 |
| [#158](https://github.com/Symprex/link-shortener/security/dependabot/158) | high | Unbounded expansion length → OOM crash | 1.1.17 |
| [#159](https://github.com/Symprex/link-shortener/security/dependabot/159) | high | Unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation | 1.1.18 |
| [#157](https://github.com/Symprex/link-shortener/security/dependabot/157) | high | Exponential-time expansion of consecutive non-expanding `{}` groups | 2.1.2 |
| [#150](https://github.com/Symprex/link-shortener/security/dependabot/150) | high | Unbounded expansion length → OOM crash | 2.1.3 |
| [#160](https://github.com/Symprex/link-shortener/security/dependabot/160) | high | Unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation | 2.1.4 |
| [#141](https://github.com/Symprex/link-shortener/security/dependabot/141) | high | Exponential-time expansion of consecutive non-expanding `{}` groups | 5.0.7 |
| [#148](https://github.com/Symprex/link-shortener/security/dependabot/148) | high | Unbounded expansion length → OOM crash | 5.0.8 |
| [#151](https://github.com/Symprex/link-shortener/security/dependabot/151) | high | Unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation | 5.0.9 |

## Change

```diff
-      "brace-expansion@1": "1.1.13",
-      "brace-expansion@2": "^2.1.2",
-      "brace-expansion@5": "^5.0.6",
+      "brace-expansion@1": "^1.1.18",
+      "brace-expansion@2": "^2.1.4",
+      "brace-expansion@5": "^5.0.9",
```

Each major now sits exactly at the highest patched version for its advisory series — 1.1.18, 2.1.4, 5.0.9 — and all three are the current latest within their major. No `brace-expansion` 3.x or 4.x exists in the tree, so alert #141's `>= 3.0.0` lower bound is satisfied by the 5.x bump alone.

The `@2` floor moved from `^2.1.2` to `^2.1.4` even though `^2.1.2` already floated to 2.1.4. A floor below the advisory ceiling is exactly what let a stale `postcss@8.5.15` persist in this same lockfile under a `^8.5.15` override; pinning the floor to the resolved version removes that possibility.

All three bumps are patch-level within their major, and each stays inside its consuming `minimatch`'s declared range, so no `minimatch` resolution moves.

## Verification

- `pnpm install --frozen-lockfile` succeeds; `postinstall` (`build:map` + `nuxt prepare`) completes.
- `grep '^  brace-expansion@' pnpm-lock.yaml` shows exactly `1.1.18`, `2.1.4`, `5.0.9` — no vulnerable copy remains.
- Expansion and glob matching verified across the bumps:
  - `require('brace-expansion')('a{b,c}d')` → `["abd","acd"]`
  - `minimatch('src/a.ts','src/{a,b}.ts')` → `true`; `minimatch('src/z.ts','src/{a,b}.ts')` → `false`
- `pnpm lint` completes a full project sweep — exercising minimatch's globbing throughout — and fails with the same 10 pre-existing style errors as `master`, in `README.md`, `app/components/dashboard/links/Link.vue`, `app/lib/utils.ts` and `nuxt.config.ts`. None are touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
