### PR TITLE
fix(deps): raise shell-quote override from exact 1.8.4 to ^1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       "picomatch@^4": "4.0.4",
       "postcss@8": "^8.5.15",
       "serialize-javascript": "7.0.5",
-      "shell-quote": "1.8.4",
+      "shell-quote": "^1.9.0",
       "srvx": "0.11.13",
       "tar": "^7.5.22",
       "vite": "7.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ overrides:
   picomatch@^4: 4.0.4
   postcss@8: ^8.5.15
   serialize-javascript: 7.0.5
-  shell-quote: 1.8.4
+  shell-quote: ^1.9.0
   srvx: 0.11.13
   tar: ^7.5.22
   vite: 7.3.5
@@ -6203,8 +6203,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
@@ -12541,7 +12541,7 @@ snapshots:
   launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
 
   lazystream@1.0.1:
     dependencies:
@@ -14303,7 +14303,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   signal-exit@3.0.7: {}
 


### PR DESCRIPTION
Closes Dependabot alert #143.

## Problem

[Alert #143](https://github.com/Symprex/link-shortener/security/dependabot/143) (high) — quadratic-complexity denial of service in `shell-quote`'s `parse()` (CWE-407). Affects `<= 1.8.4`; fixed in 1.9.0.

The notable part is that **the override was the cause, not the cure**. `pnpm.overrides` carried `"shell-quote": "1.8.4"` — an exact pin sitting precisely on the highest affected version. The only consumer, `launch-editor@2.14.1` (dev-only), already declares `"shell-quote": "^1.8.4"`, which would have floated to a patched release on its own. The pin is what held the tree back.

## Change

`"shell-quote": "1.8.4"` → `"shell-quote": "^1.9.0"`.

I kept an explicit floor rather than deleting the override outright, so a future transitive dependency can't quietly reintroduce a `< 1.9.0` resolution. It resolves to 1.10.0, comfortably inside launch-editor's `^1.8.4` range.

## Verification

- `pnpm install --frozen-lockfile` succeeds; `postinstall` (`build:map` + `nuxt prepare`) completes.
- `grep '^  shell-quote' pnpm-lock.yaml` shows only `1.10.0` — no vulnerable copy remains.
- `parse()` smoke test still behaves correctly across the 1.8.4 → 1.10.0 jump:
  `require('shell-quote').parse('foo "bar baz" | qux')` → `["foo","bar baz",{"op":"|"},"qux"]`
- `pnpm lint` fails identically to `master` (pre-existing style errors in `README.md`, `Link.vue`, `app/lib/utils.ts`, `nuxt.config.ts` — untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
